### PR TITLE
fix action precedence

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -195,6 +195,16 @@ After you have entered the URL of the search form, add &lt;code&gt;?key=***&lt;/
 			<key>QSWebSearchSource</key>
 			<string>QSWebSearchSource</string>
 		</dict>
+		<key>QSTypeDefinitions</key>
+		<dict>
+			<key>qs.url.search</key>
+			<dict>
+				<key>icon</key>
+				<string>Find</string>
+				<key>name</key>
+				<string>Search URLs</string>
+			</dict>
+		</dict>
 	</dict>
 	<key>QSRequirements</key>
 	<dict>

--- a/Info.plist
+++ b/Info.plist
@@ -68,7 +68,7 @@
 			<key>name</key>
 			<string>Search For…</string>
 			<key>precedence</key>
-			<string>4.000000</string>
+			<real>4.0</real>
 			<key>validatesObjects</key>
 			<true/>
 		</dict>

--- a/Info.plist
+++ b/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.7.1</string>
+	<string>2.7.2</string>
 	<key>CFBundleVersion</key>
-	<string>247</string>
+	<string>248</string>
 	<key>NSPrincipalClass</key>
 	<string>QSWebSearchController</string>
 	<key>QSActions</key>
@@ -67,7 +67,7 @@
 			<string>Find</string>
 			<key>name</key>
 			<string>Search For…</string>
-			<key>rankModification</key>
+			<key>precedence</key>
 			<string>4.000000</string>
 			<key>validatesObjects</key>
 			<true/>


### PR DESCRIPTION
“Search For…” was being outranked by “Open URL” because an older key
was being used.

This bit me on a fresh install under 10.10 and has bitten [at least one user][1].

[1]: /quicksilver/Quicksilver/commit/2aba72904ece9d5c56a7825a4b644cedcb6948cb#commitcomment-6453509