### PR TITLE
treat multiple lines in text as separate searches

### DIFF
--- a/Documentation.mdown
+++ b/Documentation.mdown
@@ -18,6 +18,8 @@ Google.com ⇥ Search For... ⇥ 'Steve Jobs'
 
 This action works in exactly the same way as the 'Search For...' action, but returns the results to Quicksilver's 1st pane in the form of links on the results page. This action is an [alternate action](http://qsapp.com/wiki/Alternate_Actions) to the 'Search For...' action.
 
+**NOTE:** You may use the comma trick to select multiple search URLs and/or multiple search terms. When the search text contains multiple lines of text, each line will be treated as a separate search.
+
 ### Default Web Searches (Catalog)
 
 The plugin contains two default web search lists (simple and advanced). The simple list is enabled by default. To view the entries in each list, go to the [Catalog Preferences](qs://preferences#QSCatalogPrefPane) and click the 'Plugins' tab. You should see two entries: 'Web Searches (Full List)' and 'Web Searches (Simple)'. Enable/disable them, and expand the sidebar to see their contents.

--- a/Info.plist
+++ b/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.7.1</string>
+	<string>2.8.0</string>
 	<key>CFBundleVersion</key>
-	<string>247</string>
+	<string>248</string>
 	<key>NSPrincipalClass</key>
 	<string>QSWebSearchController</string>
 	<key>QSActions</key>
@@ -122,6 +122,7 @@
 Google.com ⇥ Search For... ⇥ 'Steve Jobs'&lt;/p&gt;
 &lt;p&gt;&lt;strong&gt;Show Results For Search...&lt;/strong&gt;&lt;/p&gt;
 &lt;p&gt;This action works in exactly the same way as the 'Search For...' action, but returns the results to Quicksilver's 1st pane in the form of links on the results page. This action is an &lt;a href="http://qsapp.com/wiki/Alternate_Actions"&gt;alternate action&lt;/a&gt; to the 'Search For...' action.&lt;/p&gt;
+&lt;p&gt;&lt;strong&gt;NOTE:&lt;/strong&gt; You may use the comma trick to select multiple search URLs and/or multiple search terms. When the search text contains multiple lines of text, each line will be treated as a separate search.&lt;/p&gt;
 &lt;h3&gt;Default Web Searches (Catalog)&lt;/h3&gt;
 &lt;p&gt;The plugin contains two default web search lists (simple and advanced). The simple list is enabled by default. To view the entries in each list, go to the &lt;a href="qs://preferences#QSCatalogPrefPane"&gt;Catalog Preferences&lt;/a&gt; and click the 'Plugins' tab. You should see two entries: 'Web Searches (Full List)' and 'Web Searches (Simple)'. Enable/disable them, and expand the sidebar to see their contents.&lt;/p&gt;
 &lt;p&gt;To request the addition of a new website to either list, post on the &lt;a href="http://groups.google.com/group/blacktree-quicksilver/topics?gvc=2"&gt;support forums&lt;/a&gt;.&lt;/p&gt;

--- a/QSURLSearchActions.m
+++ b/QSURLSearchActions.m
@@ -62,15 +62,23 @@
 }
 
 - (QSObject *)doURLSearchForAction:(QSObject *)dObject withString:(QSObject *)iObject{
-	
+    NSMutableArray *searchStrings = [NSMutableArray array];
+    NSArray *rawStrings;
 	for(NSString * urlString in [dObject arrayForType:QSSearchURLType]){
-        for (QSObject *obj in [iObject splitObjects]) {
-            NSString *string = [obj stringValue];
-            if (![string length]) {
-                NSBeep();
-                NSLog(@"web search attempted with no search terms");
-                continue;
-            }
+        [searchStrings removeAllObjects];
+        rawStrings = [[iObject splitObjects] arrayByPerformingSelector:@selector(stringValue)];
+        // treat multiple lines as different searches
+        for (NSString *raw in rawStrings) {
+            [searchStrings addObjectsFromArray:[raw lines]];
+        }
+        // ignore empty lines
+        [searchStrings removeObject:@""];
+        if (![searchStrings count]) {
+            NSBeep();
+            NSLog(@"web search attempted with no search terms");
+            continue;
+        }
+        for (NSString *string in searchStrings) {
             [[QSWebSearchController sharedInstance] searchURL:urlString forString:string];
         }
 	}


### PR DESCRIPTION
As described/requested in quicksilver/Quicksilver#1879

This would allow you to select lines from a file, like

    Opeth
    Mastodon
    The Sword

and search for them all individually in one shot.

One thing it will break, however: If you have a search URL for Google Maps, you will no longer be able to select a multi-line address and search for it as-is.

So decide which use case you think is more important and either close or merge this. I have no strong feelings either way.